### PR TITLE
ヘッダーのメタタグの動的な表示の再実装

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,14 +31,14 @@
     <link rel="stylesheet" type="text/css" href="/dist/css/custom.min.css" media="screen">
 
 
-    <meta name="title" content="YassLab 株式会社 – Having a Good Life with OpenSource ;)"/>
+    <meta name="title" content="{{ page.title }}"/>
     <meta name="description"
           content="Distributed Company that Works Remotely, focusing on Ruby/Rails Web Development, Education, and OpenSource."/>
 
     <meta property="fb:admins" content="715330868"/>
     <meta property="fb:app_id" content="680598798739780"/>
-    <meta property="og:title" content="YassLab 株式会社 – Having a Good Life with OpenSource ;)"/>
-    <meta property="og:site_name" content="YassLab 株式会社 – Having a Good Life with OpenSource ;)"/>
+    <meta property="og:title" content="{{ page.title }}"/>
+    <meta property="og:site_name" content="{{ page.title }}"/>
     <meta property="og:description"
           content="Distributed Company that Works Remotely, focusing on Ruby/Rails Web Development, Education, and OpenSource."/>
     <meta property="og:image" content="https://yasslab.jp/img/logo_square.png"/>
@@ -54,7 +54,7 @@
 
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@YassLab"/>
-    <meta name="twitter:title" content="YassLab 株式会社 – Having a Good Life with OpenSource ;)"/>
+    <meta name="twitter:title" content="{{ page.title }}"/>
     <meta name="twitter:description"
           content="Distributed Company that Works Remotely, focusing on Ruby/Rails Web Development, Education, and OpenSource."/>
     <meta name="twitter:image" content="https://yasslab.jp/img/logo_square.png"/>


### PR DESCRIPTION
ヘッダーのメタタグ内においてタイトルが直接書かれていた箇所を動的に変更しました。こちらもともとそういう実装だったのを、headerを作成するタイミングで固定にしてしまってました。