### PR TITLE
Herokuの脆弱性の対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
       rainbow
       rouge
       slop (< 4.0.0)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-contrib (2.0.1)
       rack (~> 2.0)
     rack-jekyll (0.3.5)
@@ -319,7 +319,7 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     terminal-table (1.8.0)


### PR DESCRIPTION
Herokuの脆弱性の対応を行った
今回は `bundle update sprockets`で対応した
cf. https://blog.heroku.com/rails-asset-pipeline-vulnerability