### PR TITLE
Add default layout header img

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
 <div style="color: #fff;padding: 100px 0;margin-bottom: 0; background: url(../../img/{{ page.thumbnail }});">
 </div>
 {% else %}
-<div style="color: #fff;padding: 100px 0;margin-bottom: 0; background: url(../../img/bg-dark.jpg);">
+<div style="color: #fff;padding: 100px 0;margin-bottom: 0; background: url(../../img/bg-sky.jpg);">
 </div>
 {% endif %}
 <!-- MAIN CONTENT -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,12 @@
 {% include header.html %}
 
+{% if page.thumbnail %}
+<div style="color: #fff;padding: 100px 0;margin-bottom: 0; background: url(../../img/{{ page.thumbnail }});">
+</div>
+{% else %}
+<div style="color: #fff;padding: 100px 0;margin-bottom: 0; background: url(../../img/bg-dark.jpg);">
+</div>
+{% endif %}
 <!-- MAIN CONTENT -->
 <div id="main_content_wrap" class="outer container">
   <section id="main_content" class="inner row justify-content-md-center pt-5">

--- a/ja/privacy/index.md
+++ b/ja/privacy/index.md
@@ -2,6 +2,7 @@
 layout: default
 title:  Privacy Policy – YassLab 株式会社
 lang:   ja
+thumbnail: demo.png
 ---
 
 # プライバシーポリシー

--- a/ja/privacy/index.md
+++ b/ja/privacy/index.md
@@ -2,7 +2,6 @@
 layout: default
 title:  Privacy Policy – YassLab 株式会社
 lang:   ja
-thumbnail: demo.png
 ---
 
 # プライバシーポリシー


### PR DESCRIPTION
ヘッダーメニューのすぐ下にある横長の画像について。

(1) _layoutのHTML内で何か指定してある場合は、それが表示されます
(2) mdに何も書かないとデフォルトで img/bg-sky.jpg が表示されます
(3) 今後、何か新しく画像を入れたい場合には、mdに thumbnail: hoge.jpg と表記すればOK。

デフォルトで使っている空の画像サイズは、PCモニタの最大として幅1920pxにしています。
容量は26kなのでかなり軽めのはず。