### PR TITLE
Enable RSS feed in posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :jekyll_plugins do
   gem "jekyll-gist"
   gem "jekyll-coffeescript"
   gem "jekyll-assets"
+  gem 'jekyll-feed'
   gem 'qiita'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     jekyll-coffeescript (1.1.1)
       coffee-script (~> 2.2)
       coffee-script-source (~> 1.11.1)
+    jekyll-feed (0.11.0)
+      jekyll (~> 3.3)
     jekyll-gist (1.5.0)
       octokit (~> 4.2)
     jekyll-sanity (1.2.0)
@@ -201,6 +203,7 @@ DEPENDENCIES
   jekyll
   jekyll-assets
   jekyll-coffeescript
+  jekyll-feed
   jekyll-gist
   mechanize
   pry-byebug

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,16 @@
 permalink: /:title
+
+# Variables to configure RSS feed
+# https://github.com/jekyll/jekyll-feed
+title: YassLab 株式会社
+description: "沖縄と東京を拠点にしたソフトウェア開発会社です。RailsチュートリアルやRailsガイドを運営し、月額制開発支援サービスも提供しています。"
+url: https://yasslab.jp
+author:
+  name: YassLab 株式会社
+  image: /img/logo_square.png
+  twitter: YassLab
+
+# Variables for internal use
 company:
   vision: "Having a Good Life with OpenSource ;)"
   name:  YassLab

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,7 @@ plugins:
   - jekyll-gist
   - jekyll-coffeescript
   - jekyll-assets
+  - jekyll-feed
   - qiita
 exclude:
   - README.md


### PR DESCRIPTION
Enable to generate [RSS feed](https://yasslab.jp/feed.xml) for [posts](https://yasslab.jp/ja/#posts) like this:

![image](https://user-images.githubusercontent.com/155807/52906624-c4ce9e00-3292-11e9-8efc-83ec3b8fa618.png)

cf. https://github.com/jekyll/jekyll-feed