### PR TITLE
Use relative path for recent posts with no errors in CI

### DIFF
--- a/_includes/recent_posts.html
+++ b/_includes/recent_posts.html
@@ -20,7 +20,9 @@
         <span class="h5">
           <a href="{{ site.base_url }}{{ post.url }}">
             {{ post.title }}
-            <!--<small>{{ post.date | date_to_string }}</small>-->
+            <!-- TODO: Need a good design for showing this info
+		 <small>{{ post.date | date_to_string }}</small>
+	    -->
           </a>
         </span>
       </li>

--- a/_includes/recent_posts.html
+++ b/_includes/recent_posts.html
@@ -18,7 +18,7 @@
     {% if same_tag_count >= min_common_tags %}
       <li style="padding-top: 7px;">
         <span class="h5">
-          <a href="{{ site.base_url }}{{ post.url }}">
+          <a href="{{ post.url }}">
             {{ post.title }}
             <!-- TODO: Need a good design for showing this info
 		 <small>{{ post.date | date_to_string }}</small>

--- a/_includes/recent_posts.html
+++ b/_includes/recent_posts.html
@@ -18,7 +18,7 @@
     {% if same_tag_count >= min_common_tags %}
       <li style="padding-top: 7px;">
         <span class="h5">
-          <a href="{{ post.url }}">
+          <a href="{% if jekyll.environment == 'development' %}http://localhost:4000{% else %}{{ site.base_url }}{% endif %}{{ post.url }}">
             {{ post.title }}
             <!-- TODO: Need a good design for showing this info
 		 <small>{{ post.date | date_to_string }}</small>


### PR DESCRIPTION
Fix workaround code that refers to `site.base_url` in order to avoid failing in CI. ✅ 🔧 💨 