### PR TITLE
[WIP] Enable check_external_hash in HTML-Proffer option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ task test: [:build] do
   sh "bundle exec rake assets:precompile" unless ENV['SKIP_BUILD'] == '1'
   options = {
     allow_hash_href:  true,
+    check_external_hash: true,
     check_opengraph:  true,
     check_favicon:    true,
     check_html:       true,

--- a/_posts/2019-03-14-aws-award-at-fukuoka-ruby-2019.md
+++ b/_posts/2019-03-14-aws-award-at-fukuoka-ruby-2019.md
@@ -12,7 +12,7 @@ YassLab 株式会社の『[Railsチュートリアル × 反転学習](https://s
 
 ![AWS Award at Fukuoka Ruby 2019](https://i.gyazo.com/9ed5b5ec853de9a05063a3f7b9b734c7.jpg)
 
-AWS賞の受賞特典として、YassLab 株式会社はアマゾンウェブサービスジャパン株式会社よりAWSアーキテクト個別技術相談権などを頂けました。弊社が運営する『{{site.railstutorial}}』や『{{site.railsguides}}』などで積極的に活用させていただき、より多くの方々が学びやすいカタチに繋げていきたいと考えています。
+AWS賞の受賞特典として、YassLab 株式会社はアマゾンウェブサービスジャパン株式会社よりAWSアーキテクト個別技術相談権などを頂けました。弊社が運営する『{{site.railstutorial_hogehoge}}』や『{{site.railsguides}}』などで積極的に活用させていただき、より多くの方々が学びやすいカタチに繋げていきたいと考えています。
 
 また、フクオカRuby大賞の本審査 (10分間のプレゼンテーション、5分間の質疑応答) で使われたスライド資料は下記から公開しております。
 


### PR DESCRIPTION
Fix #86 

次のような状況を検知して、CI 結果がエラーになって落ちていてほしいが... 😹💭 (試行錯誤中)

**TODO: Need to be squashed later.**

![image](https://user-images.githubusercontent.com/155807/54335324-f78a6d00-466b-11e9-9c2d-cbde9525cc96.png)

> ## 引用 from #86 
> 
> ちょっと手元で試してみましたが、期待したような動きにはなってなさそうでした... 😹
> 
> ![image](https://user-images.githubusercontent.com/155807/54333767-09b5dc80-4667-11e9-9b18-e10af62632a6.png)
> 
> cf. https://github.com/gjtorikian/html-proofer/wiki/Using-HTMLProofer-From-Ruby-and-Travis
> 
> 👀 💭 (有効にしたはずなのに check_external_hash が有効になってないようにも見える...? )