### PR TITLE
トップページのキャッチコピーのフォントを変更した

### DIFF
--- a/src/_mystyle.scss
+++ b/src/_mystyle.scss
@@ -53,6 +53,7 @@ br.ignore-sp{
 // font setting
 
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP:400,700');
+@import url('https://fonts.googleapis.com/css?family=Oswald:600|Oxygen:700');//トップのキャッチコピー専用
 
 @mixin link() {
   background: linear-gradient(transparent 60%, #ff6 60%);
@@ -108,6 +109,7 @@ html {
       font-size: 2.8rem;
       color:#fff;
       padding-top: 30px;
+      font-family: 'Oxygen', sans-serif;
       @include media-breakpoint-down(sm) {
         font-size: 1.5rem;
         padding-top: 15px;


### PR DESCRIPTION
## 変更前
比較動画: http://recordit.co/HpJTWCEhjO

## 変更後
日英とも「Oxygen」というGoogle Font にしました。
選んだ理由：YassLabロゴのFuturaに形が似ていて、現状よりも少し太めのサンセリフ、GoogleWeb Font の中で使えるもの

![image](https://user-images.githubusercontent.com/5765654/55856148-6fcd4b00-5ba4-11e9-9229-0d7e8b711aac.png)
![image](https://user-images.githubusercontent.com/5765654/55856159-778cef80-5ba4-11e9-8e52-e59cbb8dc5c7.png)
![image](https://user-images.githubusercontent.com/5765654/55856180-7eb3fd80-5ba4-11e9-8327-320a59a11204.png)

Fix #92 