### PR TITLE
Check if Heroku Review App works with HTTPS protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,11 @@
 source 'http://rubygems.org'
+
+# Replace 'git' with 'https' protocol
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 ruby '2.6.3'
 
 gem "jekyll", github: "jekyll/jekyll"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/jekyll/jekyll.git
+  remote: https://github.com/jekyll/jekyll.git
   revision: 0f4b7be88ddd39593c226486f056f7402e75299c
   specs:
     jekyll (4.0.0.pre.alpha1)


### PR DESCRIPTION
This commit reverts https://github.com/yasslab/yasslab.jp/pull/123/commits/b5f00313a444f2985461356c5c6511171edb89da commit in PR #123, and check if generated Heroku Review Apps for this PR works correctly in this protocol

## Failed building due to the change of protocol

[![image](https://user-images.githubusercontent.com/155807/62007419-20794d80-b188-11e9-8be0-e3cd8acaf332.png)](https://github.com/yasslab/yasslab.jp/pull/123)


