### PR TITLE
Stop pruning to reuse devDepndencies generated in previous buildpack

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ task default: 'assets:precompile'
 namespace :assets do
   task :precompile do
     Rake::Task['clean'].invoke
+    sh 'npm prune --production'
     sh 'JEKYLL_ENV=production bundle exec jekyll build'
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,10 +3,10 @@ require "bundler/setup"
 
 task default: 'assets:precompile'
 
+# Override assets:precomiple in Heroku deployment
 namespace :assets do
   task :precompile do
     Rake::Task['clean'].invoke
-    sh 'npm install'
     sh 'JEKYLL_ENV=production bundle exec jekyll build'
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ task default: 'assets:precompile'
 # Override assets:precomiple in Heroku deployment
 namespace :assets do
   task :precompile do
-    Rake::Task['clean'].invoke
     sh 'npm prune --production'
     sh 'JEKYLL_ENV=production bundle exec jekyll build'
   end

--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,8 @@ task default: 'assets:precompile'
 # Override assets:precomiple in Heroku deployment
 namespace :assets do
   task :precompile do
-    sh 'npm prune --production'
     sh 'JEKYLL_ENV=production bundle exec jekyll build'
+    sh 'npm prune --production'
   end
 end
 


### PR DESCRIPTION
cf. https://devcenter.heroku.com/articles/nodejs-support#skip-pruning

> ### Skip pruning
> If you need access to packages declared under `devDependencies` in a different buildpack or at runtime, then you can set `NPM_CONFIG_PRODUCTION=false` or `YARN_PRODUCTION=false` to skip the pruning step.