### PR TITLE
配色ガイドの色の名前を修正

### DIFF
--- a/_data/styles/railsguides.yml
+++ b/_data/styles/railsguides.yml
@@ -16,7 +16,7 @@
       code: f1938c
     - name: main-lightest
       code: ffeded
-    - name: main-light
+    - name: main-vivid
       code: ee3f3f
 - colorSet:
   name:


### PR DESCRIPTION
main-light -> main-vivid