### PR TITLE
content-security-policyにtwemojiを追加

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -27,7 +27,7 @@ use Rack::TryStatic,
       'X-Xss-Protection'          => '1; mode=block',
       'X-Content-Type-Options'    => 'nosniff',
       'X-Frame-Options'           => 'DENY',
-      'Content-Security-Policy'   => "default-src 'self' 'unsafe-inline' 'unsafe-eval' *.google.com *.google-analytics.com  *.googleusercontent.com *.facebook.net *.facebook.com *.twitter.com *.github.com buttons.github.io *.hatena.ne.jp *.st-hatena.com *.wufoo.com *.mailchimp.com *.twimg.com speakerdeck.com speakerd.herokuapp.com coderdojo.jp code.jquery.com fonts.googleapis.com fonts.gstatic.com cdnjs.cloudflare.com stackpath.bootstrapcdn.com public.slidesharecdn.com www.slideshare.net www.youtube.com www.w3.org d.line-scdn.net banners.itunes.apple.com; img-src * 'self' data: https:;"
+      'Content-Security-Policy'   => "default-src 'self' 'unsafe-inline' 'unsafe-eval' *.google.com *.google-analytics.com  *.googleusercontent.com *.facebook.net *.facebook.com *.twitter.com *.github.com buttons.github.io *.hatena.ne.jp *.st-hatena.com *.wufoo.com *.mailchimp.com *.twimg.com speakerdeck.com speakerd.herokuapp.com coderdojo.jp code.jquery.com fonts.googleapis.com fonts.gstatic.com cdnjs.cloudflare.com stackpath.bootstrapcdn.com public.slidesharecdn.com www.slideshare.net www.youtube.com www.w3.org d.line-scdn.net banners.itunes.apple.com twemoji.maxcdn.com; img-src * 'self' data: https:;"
     }],
     [['html'],    { 'Content-Type'  => 'text/html; charset=utf-8'}],
     [['txt'],     { 'Content-Type'  => 'text/plain; charset=utf-8'}],


### PR DESCRIPTION
close https://github.com/yasslab/yasslab.jp/issues/325
twemojiのscriptが読み込めていなかったので、Content-Security-Policyを変更して、twemojiを読み込めるようにしました。
参考: https://qiita.com/sola-msr/items/1f3106cb4a097c883880