### PR TITLE
Test out new idobata notify without relying on git to get commit on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         bundle exec rspec spec/qiita.rb
 
     - name: 🔔 Notify results
-      uses: yasslab/idobata_notify@remove-git # https://github.com/yasslab/idobata_notify
+      uses: yasslab/idobata_notify@main # https://github.com/yasslab/idobata_notify
       if: always()
       with:
         idobata_hook_url: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}
@@ -59,4 +59,3 @@ jobs:
         heroku_app_name: 'yasslab-jp'
         heroku_email:    'yohei@yasslab.jp'
         healthcheck:     'https://yasslab.jp/health'
-


### PR DESCRIPTION
## やりたいこと

対応してる Git が入ってない環境がある場合 `git log` や `git rev-parse` ができない場合があるので、その場合でもコミットが取得できるようにしてたい。

> The repository will be downloaded using the GitHub REST API
> To create a local Git repository instead, add Git 2.18 or higher to the PATH


https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-example-33
