### PR TITLE
Fetch and cache Japanese holidays

### DIFF
--- a/.github/workflows/scheduler_daily.yml
+++ b/.github/workflows/scheduler_daily.yml
@@ -50,6 +50,40 @@ jobs:
         GOOGLE_SECRETS:      ${{ secrets.GOOGLE_SECRETS  }}
         GOOGLE_TOKENS:       ${{ secrets.GOOGLE_TOKENS   }}
 
+    - name: ♨️ Fetch Japanese holidays to cache
+      run: |
+        bundle exec rake fetch_japanese_holidays
+        echo "NEW_HOLIDAY=false" >> $GITHUB_ENV
+        if [ -n "$(git status --porcelain)" ]; then
+          git config --global user.name  "Yohei Yasukawa"
+          git config --global user.email "yohei@yasslab.jp"
+          git checkout main
+          git add holidays.json
+          git commit -m '🤖 Upsert holiday data by GitHub Actions'
+          git push origin main
+          echo "NEW_HOLIDAY=true" >> $GITHUB_ENV
+        else
+          echo "No new holiday(s) found."
+        fi
+      env:
+        GITHUB_TOKEN:
+
+    - name: ✅ No recent articles found
+      if: ${{ env.NEW_HOLIDAY == 'false' }}
+      run: |
+        echo "No new holiday(s) found."
+
+    - name: 🚀 Deploy to Heroku if recent article(s) found
+      if: ${{ env.NEW_HOLIDAY == 'true' }}
+      uses: akhileshns/heroku-deploy@v3.4.6
+      with:
+        branch:          'main'
+        usedocker:       false
+        heroku_api_key:   ${{ secrets.HEROKU_API_KEY }}
+        heroku_app_name: 'yasslab-jp'
+        heroku_email:    'yohei@yasslab.jp'
+        healthcheck:     'https://yasslab.jp/health'
+
     #- name: 🚨 Notify if tasks in GitHub Actions failed
     #  env:
     #    IDOBATA_GITHUB_ACTIONS: ${{ secrets.IDOBATA_GITHUB_ACTIONS }}

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,11 @@ task :share_gumroad_updates do |task, args|
   ruby "tasks/share_gumroad_updates.rb"
 end
 
+desc "Fetch and cache holidays from Japanese Cabinet Office (CAO)"
+task :fetch_japanese_holidays do |task, args|
+  ruby "tasks/fetch_japanese_holidays.rb"
+end
+
 desc "Share opt-in Health Planet user record"
 task :share_health_planet do |task, args|
   ruby "tasks/share_health_planet.rb"

--- a/tasks/fetch_japanese_holidays.rb
+++ b/tasks/fetch_japanese_holidays.rb
@@ -1,0 +1,18 @@
+require 'net/http'
+require 'uri'
+require 'date'
+require 'json'
+require 'kconv'
+
+#curl -sL https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv | iconv -f cp932
+uri      = URI.parse("https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv")
+response = Net::HTTP.get_response(uri)
+holidays = response.body.toutf8.lines(chomp: true).to_a[1..].map{|l| Date.parse(l.split(',')[0]).to_s}
+# holidays.first => "1955-01-01"
+#p response.code
+#p holidays
+
+File.open('holidays.json', 'w') do |f|
+  #JSON.dump(holidays, f)
+  f.write(JSON.pretty_generate holidays)
+end


### PR DESCRIPTION
日本の祝日データ取得のために元データ（内閣府）に毎回アクセスしないで済むように、日本の祝日データを `https://yasslab.jp/holidays.json` から取得できるようにする PR です。

## 元データの内容

```console
$ curl -sL https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv | iconv -f cp932

国民の祝日・休日月日,国民の祝日・休日名称
1955/1/1,元日
1955/1/15,成人の日
1955/3/21,春分の日
1955/4/29,天皇誕生日
1955/5/3,憲法記念日
1955/5/5,こどもの日
1955/9/24,秋分の日
1955/11/3,文化の日
1955/11/23,勤労感謝の日
1956/1/1,元日
1956/1/15,成人の日
...
2023/1/1,元日
2023/1/2,休日
2023/1/9,成人の日
2023/2/11,建国記念の日
2023/2/23,天皇誕生日
2023/3/21,春分の日
2023/4/29,昭和の日
2023/5/3,憲法記念日
2023/5/4,みどりの日
2023/5/5,こどもの日
2023/7/17,海の日
2023/8/11,山の日
2023/9/18,敬老の日
2023/9/23,秋分の日
2023/10/9,スポーツの日
2023/11/3,文化の日
2023/11/23,勤労感謝の日
2024/1/1,元日
2024/1/8,成人の日
2024/2/11,建国記念の日
2024/2/12,休日
2024/2/23,天皇誕生日
2024/3/20,春分の日
2024/4/29,昭和の日
2024/5/3,憲法記念日
2024/5/4,みどりの日
2024/5/5,こどもの日
2024/5/6,休日
2024/7/15,海の日
2024/8/11,山の日
2024/8/12,休日
2024/9/16,敬老の日
2024/9/22,秋分の日
2024/9/23,休日
2024/10/14,スポーツの日
2024/11/3,文化の日
2024/11/4,休日
2024/11/23,勤労感謝の日
```
