### PR TITLE
feat(docs): 公開資料ページの下部にもパンくずを追加

### DIFF
--- a/_includes/docs_breadcrumb.html
+++ b/_includes/docs_breadcrumb.html
@@ -1,0 +1,9 @@
+{%- comment -%}
+公開資料（/ja/docs）ページのパンくずナビ。
+legal レイアウトの本文の上下で共有するため、定義はここ1箇所に集約する（DRY）。
+余白は呼び出し側の <div> で調整する。
+{%- endcomment -%}
+📑
+<a href="/ja">TOP</a> →
+<a href="/ja/docs">公開資料</a> →
+{{ page.title }}

--- a/_layouts/legal.html
+++ b/_layouts/legal.html
@@ -21,12 +21,12 @@
        .entry_content p { margin-bottom: 15px; }
       </style>
       <div style="padding-bottom: 30px;">
-	📑
-	<a href="/ja">TOP</a> →
-	<a href="/ja/docs">公開資料</a> →
-	{{ page.title }}
+	{% include docs_breadcrumb.html %}
       </div>
       {{ content }}
+      <div style="padding-top: 30px;">
+	{% include docs_breadcrumb.html %}
+      </div>
     </div>
   </section>
 </div>


### PR DESCRIPTION
公開資料 (/ja/docs) 各ページの本文下部にもパンくずを追加しました。定義は共有パーシャルに集約し (DRY)、legal レイアウト経由で全ページに自動適用されます (AUTO)。

<img width="528" height="271" alt="image" src="https://github.com/user-attachments/assets/ff615fd6-b8b9-466e-af3f-ec1d29779859" />

