### PR TITLE
feat(note): タイトル更新時に news.yml を upsert する

### DIFF
--- a/spec/upsert_recent_notes_spec.rb
+++ b/spec/upsert_recent_notes_spec.rb
@@ -42,6 +42,65 @@ describe '#clean_note_title' do
   end
 end
 
+# note.com は公開後に記事タイトルを編集することがある。以前は
+# `next if urls.include?(item.link)` で既存 URL をスキップしていたため、
+# タイトル変更が反映されなかった。update_entry_titles は該当エントリの
+# title 行だけをその場で書き換え、手書きの YAML 整形（クォートの有無・
+# キーのスペース幅・空行）を保つ。
+describe '#update_entry_titles' do
+  let(:yaml_text) do
+    <<~YAML
+      - title: '🌐 Old JP Title'
+        title_en: '🌐 Old EN Title'
+        date:  2026-07-21
+        url:   https://note.com/yasslab/n/n541f711678c9
+
+      - title: 別の記事はそのまま
+        title_en: 'Another entry stays'
+        date: 2026-07-10
+        url: https://note.com/yasslab/n/naa68e1ad293a
+    YAML
+  end
+
+  it 'updates the JP and EN titles of the matching entry only' do
+    result = update_entry_titles(yaml_text,
+                                 url: 'https://note.com/yasslab/n/n541f711678c9',
+                                 title: '🌐 New JP Title',
+                                 title_en: '🌐 New EN Title')
+    expect(result).to include("- title: '🌐 New JP Title'")
+    expect(result).to include("  title_en: '🌐 New EN Title'")
+    # 他のエントリは変更されない。
+    expect(result).to include('- title: 別の記事はそのまま')
+    # date / url 行とそのスペーシングは保持される。
+    expect(result).to include("  date:  2026-07-21\n  url:   https://note.com/yasslab/n/n541f711678c9")
+  end
+
+  it 'keeps the existing title_en when the new one is nil' do
+    result = update_entry_titles(yaml_text,
+                                 url: 'https://note.com/yasslab/n/n541f711678c9',
+                                 title: '🌐 New JP Title',
+                                 title_en: nil)
+    expect(result).to include("- title: '🌐 New JP Title'")
+    expect(result).to include("  title_en: '🌐 Old EN Title'")
+  end
+
+  it 'escapes single quotes in the new title' do
+    result = update_entry_titles(yaml_text,
+                                 url: 'https://note.com/yasslab/n/n541f711678c9',
+                                 title: "It's updated",
+                                 title_en: nil)
+    expect(result).to include("- title: 'It''s updated'")
+  end
+
+  it 'returns the text unchanged when the url is not found' do
+    result = update_entry_titles(yaml_text,
+                                 url: 'https://note.com/yasslab/n/nonexistent',
+                                 title: 'X',
+                                 title_en: 'Y')
+    expect(result).to eq yaml_text
+  end
+end
+
 describe '#normalize_title' do
   it 'inserts a space after a glued emoji prefix' do
     expect(normalize_title('📕Rails Guides now supports Rails 7.2'))

--- a/tasks/upsert_recent_notes.rb
+++ b/tasks/upsert_recent_notes.rb
@@ -56,6 +56,29 @@ rescue => e
   nil
 end
 
+# note.com は公開後に記事タイトルを編集することがある。`url` で特定した
+# エントリの title / title_en 行だけを書き換え、周囲の手書き YAML 整形
+# （インデント・キーのスペース幅・空行・他と揃えたクォート）を保つ。
+# title_en が nil のときは既存の title_en を変更しない。
+def update_entry_titles(yaml_text, url:, title:, title_en:)
+  lines = yaml_text.lines
+  idx = lines.index { |line| line.match?(/\A\s*url:\s+#{Regexp.escape(url)}\s*\z/) }
+  return yaml_text unless idx
+
+  # ブロックは直前の空行の次から始まる。title / title_en は url より前にある。
+  start = idx
+  start -= 1 while start.positive? && !lines[start - 1].strip.empty?
+
+  (start...idx).each do |i|
+    if lines[i] =~ /\A(\s*(?:-\s+)?)title:\s/
+      lines[i] = "#{$1}title: #{yaml_single_quote(title)}\n"
+    elsif title_en && lines[i] =~ /\A(\s*(?:-\s+)?)title_en:\s/
+      lines[i] = "#{$1}title_en: #{yaml_single_quote(title_en)}\n"
+    end
+  end
+  lines.join
+end
+
 def note_key(url)
   URI(url).path.split('/').last
 rescue URI::InvalidURIError
@@ -106,14 +129,26 @@ if __FILE__ == $PROGRAM_NAME
   agent.user_agent_alias = 'Mac Safari'
 
   # Parse RSS and get yaml text
-  urls = load_news_yaml.map{|h| h['url']}
+  existing_by_url = load_news_yaml.each_with_object({}) { |h, m| m[h['url']] = h }
   news = ''
+  content = IO.read(NEWS_YAML)
+  updated_count = 0
+
   rss.items.each.with_index(1) do |item, index|
     break if index > number_of_fetching_articles
-    next  if urls.include? item.link
+    title = normalize_title(item.title)
+
+    if (entry = existing_by_url[item.link])
+      # 既存記事: note.com 側でタイトルが変わったときだけ更新する。
+      next if entry['title'] == title
+
+      title_en = normalize_title(note_title_en(agent, item.link))
+      content  = update_entry_titles(content, url: item.link, title: title, title_en: title_en)
+      updated_count += 1
+      next
+    end
 
     download_note_image(agent, item.link, note_image_url(agent, item.link))
-    title    = normalize_title(item.title)
     title_en = normalize_title(note_title_en(agent, item.link))
 
     news << "- title: #{yaml_single_quote(title)}\n"
@@ -122,10 +157,11 @@ if __FILE__ == $PROGRAM_NAME
     news << "  url:   #{item.link}\n\n"
   end
 
-  if news.empty?
-    puts "✅ No articles recently published."
+  if news.empty? && updated_count.zero?
+    puts "✅ No articles recently published or updated."
   else
-    puts "🆕 Found new article(s)."
-    IO.write(NEWS_YAML, news + IO.read(NEWS_YAML))
+    puts "🆕 Found new article(s)."         unless news.empty?
+    puts "✏️ Updated #{updated_count} title(s)." if updated_count.positive?
+    IO.write(NEWS_YAML, news + content)
   end
 end


### PR DESCRIPTION
## 概要

note.com は公開後に記事タイトルを編集することがあるが、これまでは `tasks/upsert_recent_notes.rb` が既存 URL を `next` でスキップしていたため、一度取得したタイトルは `news.yml` に反映されなかった。本 PR でタイトル変更を検知して upsert（更新）できるようにする。

## 変更点

- `update_entry_titles` を追加（純関数）
  - `url` で特定したエントリの `title` / `title_en` 行だけをその場で書き換える
  - `news.yml` は手書きで整形されている（クォート有無・スペース幅が不揃い）ため、YAML 全体を再ダンプせず該当ブロックのみ置換して整形を保つ
  - `title_en` が `nil`（取得失敗）のときは既存値を残す
- メインループを upsert 化
  - 既存記事は RSS の日本語タイトルと突き合わせ、**差分があるときだけ** `?hl=en` を取得して両タイトルをリフレッシュ
  - 出力に `✏️ Updated N title(s).` を追加

## 設計上の割り切り

更新トリガーは RSS で無料取得できる日本語タイトルの差分。英語タイトルだけが変わった場合は検知しない（毎時全記事へ HTTP を投げるコストを避けるため）。

## テスト

- `spec/upsert_recent_notes_spec.rb` に `update_entry_titles` のテストを 4 件追加（全 16 例 green）
- ローカルで実 RSS に対して実行し、実際にタイトル変更されていた 1 件を検出・整形を保ったまま更新できることを確認

## 動作検証（本番 Actions で確認済み）

`_data/news.yml` の実データ更新は本 PR に含めず、マージ後に本番の hourly scheduler（`scheduler_hourly.yml`）へ委ねて検証した。

マージ後に手動 dispatch した run（`workflow_dispatch` / main）は成功し、`📜 Upsert recent news from RSS` ステップで `HAS_NEWS=true` を検知 → Actions が `🤖 Upsert news by GitHub Actions`（176c124501324b13daee6b6f003440dd284cf863）を自動コミット・push・Heroku デプロイまで完走した。実際に反映された差分は次のとおり:

```diff
-- title: '🌐 ラズベリーパイ財団主催の国際サミット参加報告会に協賛'
-  title_en: '🌐 ラズベリーパイ財団主催の国際サミット参加報告会に協賛'
+- title: '🌐 国際サミット「Raspberry Fields」の参加報告会に協賛'
+  title_en: '🌐 国際サミット「Raspberry Fields」の参加報告会に協賛'
   date:  2026-07-21
   url:   https://note.com/yasslab/n/n541f711678c9
```

`date:` の 2 スペース整形も保たれており、該当ブロックだけを書き換える設計が本番でも意図どおり機能した。